### PR TITLE
Disable Dyad token usage limits for local demo

### DIFF
--- a/src/app/TitleBar.tsx
+++ b/src/app/TitleBar.tsx
@@ -72,8 +72,8 @@ export const TitleBar = () => {
     }
   };
 
-  const isDyadPro = !!settings?.providerSettings?.auto?.apiKey?.value;
-  const isDyadProEnabled = Boolean(settings?.enableDyadPro);
+  const isDyadPro = settings?.enableDyadPro !== false;
+  const isDyadProEnabled = settings?.enableDyadPro !== false;
 
   return (
     <>
@@ -225,9 +225,11 @@ export function DyadProButton({
 }
 
 export function AICreditStatus({ userBudget }: { userBudget: UserBudgetInfo }) {
-  const remaining = Math.round(
+  const remainingRaw = Math.round(
     userBudget.totalCredits - userBudget.usedCredits,
   );
+  const remaining =
+    userBudget.totalCredits >= Number.MAX_SAFE_INTEGER ? "∞" : remainingRaw;
   return (
     <Tooltip>
       <TooltipTrigger>

--- a/src/components/ProModeSelector.tsx
+++ b/src/components/ProModeSelector.tsx
@@ -19,18 +19,12 @@ export function ProModeSelector() {
   const { settings, updateSettings } = useSettings();
 
   const toggleWebSearch = () => {
-    if (!settings?.enableDyadPro) {
-      return;
-    }
     updateSettings({
       enableProWebSearch: !settings?.enableProWebSearch,
     });
   };
 
   const toggleLazyEdits = () => {
-    if (!settings?.enableDyadPro) {
-      return;
-    }
     updateSettings({
       enableProLazyEditsMode: !settings?.enableProLazyEditsMode,
     });
@@ -39,9 +33,6 @@ export function ProModeSelector() {
   const handleSmartContextChange = (
     newValue: "off" | "conservative" | "balanced",
   ) => {
-    if (!settings?.enableDyadPro) {
-      return;
-    }
     if (newValue === "off") {
       updateSettings({
         enableProSmartFilesContextMode: false,
@@ -61,23 +52,16 @@ export function ProModeSelector() {
   };
 
   const toggleProEnabled = () => {
-    const nextValue = !settings?.enableDyadPro;
-    if (nextValue) {
-      updateSettings({
-        enableDyadPro: true,
-      });
-      return;
-    }
     updateSettings({
-      enableDyadPro: false,
-      enableProWebSearch: false,
-      enableProLazyEditsMode: false,
-      enableProSmartFilesContextMode: false,
-      proSmartContextOption: undefined,
+      enableDyadPro: true,
+      enableProWebSearch: true,
+      enableProLazyEditsMode: true,
+      enableProSmartFilesContextMode: true,
+      proSmartContextOption: settings?.proSmartContextOption ?? "balanced",
     });
   };
 
-  const proModeEnabled = Boolean(settings?.enableDyadPro);
+  const proModeEnabled = true;
 
   return (
     <Popover>
@@ -109,7 +93,6 @@ export function ProModeSelector() {
             <button
               type="button"
               className="inline-flex items-center justify-center gap-2 rounded-md border border-primary/30 bg-primary/10 px-3 py-2 text-sm font-medium text-primary shadow-sm transition-colors hover:bg-primary/20 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              disabled
             >
               Unlock Pro modes
             </button>

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -38,7 +38,7 @@ export function useSettings() {
       processSettingsForTelemetry(userSettings);
       if (!isInitialLoad && appVersion) {
         posthog.capture("app:initial-load", {
-          isPro: Boolean(userSettings.providerSettings?.auto?.apiKey?.value),
+          isPro: userSettings.enableDyadPro !== false,
           appVersion,
         });
         isInitialLoad = true;

--- a/src/ipc/handlers/pro_handlers.ts
+++ b/src/ipc/handlers/pro_handlers.ts
@@ -1,66 +1,21 @@
-import fetch from "node-fetch"; // Electron main process might need node-fetch
 import log from "electron-log";
 import { createLoggedHandler } from "./safe_handle";
-import { readSettings } from "../../main/settings"; // Assuming settings are read this way
-import { UserBudgetInfo, UserBudgetInfoSchema } from "../ipc_types";
-import { IS_TEST_BUILD } from "../utils/test_utils";
+import { UserBudgetInfo } from "../ipc_types";
 
 const logger = log.scope("pro_handlers");
 const handle = createLoggedHandler(logger);
 
-const CONVERSION_RATIO = (10 * 3) / 2;
+const UNLIMITED_BUDGET: UserBudgetInfo = {
+  usedCredits: 0,
+  totalCredits: Number.MAX_SAFE_INTEGER,
+  budgetResetDate: new Date("2999-12-31T23:59:59Z"),
+};
 
 export function registerProHandlers() {
   // This method should try to avoid throwing errors because this is auxiliary
   // information and isn't critical to using the app
   handle("get-user-budget", async (): Promise<UserBudgetInfo | null> => {
-    if (IS_TEST_BUILD) {
-      // Avoid spamming the API in E2E tests.
-      return null;
-    }
-    logger.info("Attempting to fetch user budget information.");
-
-    const settings = readSettings();
-
-    const apiKey = settings.providerSettings?.auto?.apiKey?.value;
-
-    if (!apiKey) {
-      logger.error("LLM Gateway API key (Dyad Pro) is not configured.");
-      return null;
-    }
-
-    const url = "https://llm-gateway.dyad.sh/user/info";
-    const headers = {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    };
-
-    try {
-      // Use native fetch if available, otherwise node-fetch will be used via import
-      const response = await fetch(url, {
-        method: "GET",
-        headers: headers,
-      });
-
-      if (!response.ok) {
-        const errorBody = await response.text();
-        logger.error(
-          `Failed to fetch user budget. Status: ${response.status}. Body: ${errorBody}`,
-        );
-        return null;
-      }
-
-      const data = await response.json();
-      const userInfoData = data["user_info"];
-      logger.info("Successfully fetched user budget information.");
-      return UserBudgetInfoSchema.parse({
-        usedCredits: userInfoData["spend"] * CONVERSION_RATIO,
-        totalCredits: userInfoData["max_budget"] * CONVERSION_RATIO,
-        budgetResetDate: new Date(userInfoData["budget_reset_at"]),
-      });
-    } catch (error: any) {
-      logger.error(`Error fetching user budget: ${error.message}`, error);
-      return null;
-    }
+    logger.info("Returning unlimited Dyad Pro budget information.");
+    return UNLIMITED_BUDGET;
   });
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -259,11 +259,11 @@ export const UserSettingsSchema = z.object({
 export type UserSettings = z.infer<typeof UserSettingsSchema>;
 
 export function isDyadProEnabled(settings: UserSettings): boolean {
-  return settings.enableDyadPro === true && hasDyadProKey(settings);
+  return settings.enableDyadPro !== false;
 }
 
 export function hasDyadProKey(settings: UserSettings): boolean {
-  return !!settings.providerSettings?.auto?.apiKey?.value;
+  return true;
 }
 
 // Define interfaces for the props

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -27,8 +27,10 @@ const DEFAULT_SETTINGS: UserSettings = {
   telemetryUserId: uuidv4(),
   hasRunBefore: false,
   experiments: {},
+  enableDyadPro: true,
   enableProLazyEditsMode: true,
   enableProSmartFilesContextMode: true,
+  enableProWebSearch: true,
   selectedChatMode: "build",
   enableAutoFixProblems: false,
   enableAutoUpdate: true,
@@ -54,6 +56,10 @@ export function readSettings(): UserSettings {
       ...DEFAULT_SETTINGS,
       ...rawSettings,
     };
+    combinedSettings.enableDyadPro = true;
+    combinedSettings.enableProLazyEditsMode = true;
+    combinedSettings.enableProSmartFilesContextMode = true;
+    combinedSettings.enableProWebSearch = true;
     const supabase = combinedSettings.supabase;
     if (supabase) {
       if (supabase.refreshToken) {
@@ -146,7 +152,14 @@ export function writeSettings(settings: Partial<UserSettings>): void {
   try {
     const filePath = getSettingsFilePath();
     const currentSettings = readSettings();
-    const newSettings = { ...currentSettings, ...settings };
+    const newSettings = {
+      ...currentSettings,
+      ...settings,
+      enableDyadPro: true,
+      enableProLazyEditsMode: true,
+      enableProSmartFilesContextMode: true,
+      enableProWebSearch: true,
+    };
     if (newSettings.githubAccessToken) {
       newSettings.githubAccessToken = encrypt(
         newSettings.githubAccessToken.value,


### PR DESCRIPTION
## Summary
- replace the Dyad Pro credit fetcher with a static unlimited budget response for local runs
- force user settings to keep all Pro features enabled by default and prevent them from being turned off
- update UI logic so Pro controls stay active and credits display as unlimited when applicable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd9095f7d08323b1209189f7d0397e