### PR TITLE
Add Docker setup for web renderer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+scaffold/node_modules
+.vite
+.vscode
+.git
+.gitignore
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.DS_Store
+out
+*.local
+coverage
+dist
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  dyad-web:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.dev
+    ports:
+      - "${DYAD_WEB_PORT:-5173}:5173"
+    environment:
+      NODE_ENV: development
+    command: ["npx","vite","--config","vite.renderer.config.mts","--host","0.0.0.0","--port","5173"]

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,8 @@
+FROM node:20-bullseye
+WORKDIR /app
+RUN apt-get update && apt-get install -y python3 build-essential && rm -rf /var/lib/apt/lists/*
+COPY package*.json ./
+RUN npm ci
+COPY . .
+EXPOSE 5173
+CMD ["npx","vite","--config","vite.renderer.config.mts","--host","0.0.0.0","--port","5173"]

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,0 +1,12 @@
+FROM node:20-bullseye AS build
+WORKDIR /app
+RUN apt-get update && apt-get install -y python3 build-essential && rm -rf /var/lib/apt/lists/*
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npx vite build --config vite.renderer.config.mts
+
+FROM nginx:1.27-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx","-g","daemon off;"]


### PR DESCRIPTION
## Summary
- add a docker-compose service that runs the Vite renderer on localhost for browser access
- provide dedicated development and production Dockerfiles for the web workflow
- add a .dockerignore to keep images lean during builds

## Testing
- docker-compose build dyad-web *(fails in sandbox: docker-compose requires the deprecated distutils module under Python 3.12)*

------
https://chatgpt.com/codex/tasks/task_e_68de47dcc0408323993128c234402b72