### PR TITLE
Update readSettings snapshots for pro defaults

### DIFF
--- a/src/__tests__/readSettings.test.ts
+++ b/src/__tests__/readSettings.test.ts
@@ -55,8 +55,10 @@ describe("readSettings", () => {
         {
           "enableAutoFixProblems": false,
           "enableAutoUpdate": true,
+          "enableDyadPro": true,
           "enableProLazyEditsMode": true,
           "enableProSmartFilesContextMode": true,
+          "enableProWebSearch": true,
           "experiments": {},
           "hasRunBefore": false,
           "providerSettings": {},
@@ -301,8 +303,10 @@ describe("readSettings", () => {
         {
           "enableAutoFixProblems": false,
           "enableAutoUpdate": true,
+          "enableDyadPro": true,
           "enableProLazyEditsMode": true,
           "enableProSmartFilesContextMode": true,
+          "enableProWebSearch": true,
           "experiments": {},
           "hasRunBefore": false,
           "providerSettings": {},

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -262,7 +262,7 @@ export function isDyadProEnabled(settings: UserSettings): boolean {
   return settings.enableDyadPro !== false;
 }
 
-export function hasDyadProKey(settings: UserSettings): boolean {
+export function hasDyadProKey(_settings: UserSettings): boolean {
   return true;
 }
 


### PR DESCRIPTION
## Summary
- update readSettings inline snapshots to reflect the new pro feature defaults persisted in settings
- silence the unused parameter warning in hasDyadProKey so lint passes without altering behavior

## Testing
- pnpm test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68de5e25d57083239af901e376aa97c1