### PR TITLE
Add Docker Compose profiles for dev and prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ No sign-up required. Just download and go.
 
 Join our growing community of AI app builders on **Reddit**: [r/dyadbuilders](https://www.reddit.com/r/dyadbuilders/) - share your projects and get help from the community!
 
+## 🐳 Docker
+
+You can run the web renderer locally through Docker Compose. The development profile serves Vite directly, while the production profile builds the static site and serves it with Nginx.
+
+```bash
+# Development server on http://localhost:5173
+docker compose --profile dev up --build
+
+# Production build served on http://localhost:8080
+docker compose --profile prod up --build
+```
+
+Override the exposed ports by exporting `DYAD_WEB_PORT` or `DYAD_PROD_PORT` before running the commands.
+
 ## 🛠️ Contributing
 
 **Dyad** is open-source (Apache 2.0 licensed).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,24 @@
 services:
   dyad-web:
+    container_name: dyad-web
+    profiles:
+      - dev
     build:
       context: .
       dockerfile: docker/Dockerfile.dev
-    ports:
-      - "${DYAD_WEB_PORT:-5173}:5173"
     environment:
       NODE_ENV: development
+    ports:
+      - "${DYAD_WEB_PORT:-5173}:5173"
     command: ["npx","vite","--config","vite.renderer.config.mts","--host","0.0.0.0","--port","5173"]
+  dyad-prod:
+    container_name: dyad-prod
+    profiles:
+      - prod
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.prod
+    environment:
+      NODE_ENV: production
+    ports:
+      - "${DYAD_PROD_PORT:-8080}:80"

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,5 +1,6 @@
 FROM node:20-bullseye AS build
 WORKDIR /app
+ENV NODE_ENV=production
 RUN apt-get update && apt-get install -y python3 build-essential && rm -rf /var/lib/apt/lists/*
 COPY package*.json ./
 RUN npm ci
@@ -7,6 +8,7 @@ COPY . .
 RUN npx vite build --config vite.renderer.config.mts
 
 FROM nginx:1.27-alpine
+ENV NODE_ENV=production
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx","-g","daemon off;"]


### PR DESCRIPTION
## Summary
- add Docker Compose profiles for local development and production-ready builds
- set production environment defaults in the Dockerfile used for Nginx
- document how to run the renderer through Docker

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de676bd9b48323b4acf9c2016b76e2