### PR TITLE
Improve Docker smoke test portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ No sign-up required. Just download and go.
 
 Join our growing community of AI app builders on **Reddit**: [r/dyadbuilders](https://www.reddit.com/r/dyadbuilders/) - share your projects and get help from the community!
 
+## 🐳 Docker
+
+You can run the web renderer locally through Docker Compose. The development profile serves Vite directly, while the production profile builds the static site and serves it with Nginx.
+
+```bash
+# Development server on http://localhost:5173
+docker compose --profile dev up --build
+
+# Production build served on http://localhost:8080
+docker compose --profile prod up --build
+```
+
+Override the exposed ports by exporting `DYAD_WEB_PORT` or `DYAD_PROD_PORT` before running the commands.
+
+Run `scripts/docker-smoke-test.sh` to automate a basic availability check against either profile. Pass `dev` or `prod` to match the desired configuration.
+
 ## 🛠️ Contributing
 
 **Dyad** is open-source (Apache 2.0 licensed).

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,7 @@
+services:
+  dyad-prod:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.prod
+    ports:
+      - "${DYAD_PROD_PORT:-8080}:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.dev
-    ports:
-      - "${DYAD_WEB_PORT:-5173}:5173"
     environment:
       NODE_ENV: development
+    ports:
+      - "${DYAD_WEB_PORT:-5173}:5173"
     command: ["npx","vite","--config","vite.renderer.config.mts","--host","0.0.0.0","--port","5173"]

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,5 +1,6 @@
 FROM node:20-bullseye AS build
 WORKDIR /app
+ENV NODE_ENV=production
 RUN apt-get update && apt-get install -y python3 build-essential && rm -rf /var/lib/apt/lists/*
 COPY package*.json ./
 RUN npm ci
@@ -7,6 +8,7 @@ COPY . .
 RUN npx vite build --config vite.renderer.config.mts
 
 FROM nginx:1.27-alpine
+ENV NODE_ENV=production
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx","-g","daemon off;"]

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "package": "npm run clean && electron-forge package",
     "make": "npm run clean && electron-forge make",
     "publish": "npm run clean && electron-forge publish",
+    "build": "npx vite build --config vite.renderer.config.mts",
     "verify-release": "node scripts/verify-release-assets.js",
     "ts": "npm run ts:main && npm run ts:workers",
     "ts:main": "npx tsc -p tsconfig.app.json --noEmit",

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PROFILE="${1:-prod}"
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  COMPOSE=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE=(docker-compose)
+else
+  echo "docker compose command not found" >&2
+  exit 127
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl command not found" >&2
+  exit 127
+fi
+if [ "$PROFILE" != "dev" ] && [ "$PROFILE" != "prod" ]; then
+  echo "unsupported profile: $PROFILE" >&2
+  exit 2
+fi
+STACK=("${COMPOSE[@]}" -f docker-compose.yml)
+if [ "$PROFILE" = "prod" ]; then
+  STACK+=( -f docker-compose.prod.yml )
+fi
+cleanup() {
+  "${STACK[@]}" down --volumes >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+"${STACK[@]}" up --build -d
+if [ "$PROFILE" = "prod" ]; then
+  PORT="${DYAD_PROD_PORT:-8080}"
+else
+  PORT="${DYAD_WEB_PORT:-5173}"
+fi
+URL="http://localhost:$PORT"
+for _ in $(seq 1 120); do
+  if curl -sf "$URL" >/dev/null 2>&1; then
+    STATUS=$("${STACK[@]}" ps --status running --services)
+    if [ -n "$STATUS" ]; then
+      exit 0
+    fi
+  fi
+  sleep 1
+  if ! "${STACK[@]}" ps >/dev/null 2>&1; then
+    echo "compose process exited unexpectedly" >&2
+    exit 1
+  fi
+  mapfile -t EXITED < <("${STACK[@]}" ps --services --status exited)
+  if [ "${#EXITED[@]}" -gt 0 ]; then
+    for SERVICE in "${EXITED[@]}"; do
+      "${STACK[@]}" logs "$SERVICE"
+    done
+    echo "service exited with errors" >&2
+    exit 1
+  fi
+done
+echo "service did not become healthy within timeout" >&2
+exit 1


### PR DESCRIPTION
## Summary
- allow the docker smoke test to work with either `docker compose` or `docker-compose`
- add an npm build script that mirrors the renderer production build command
- move the production Compose service into a separate `docker-compose.prod.yml` so the base file stays aligned with upstream

## Testing
- `CI=1 npm run build`
- `bash scripts/docker-smoke-test.sh prod` *(fails: docker compose command not found in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68de676bd9b48323b4acf9c2016b76e2